### PR TITLE
Debug vercel build error: headers cookie

### DIFF
--- a/src/app/api/campaigns/route.ts
+++ b/src/app/api/campaigns/route.ts
@@ -12,7 +12,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized: missing session cookie" }, { status: 401 });
     }
     // Get session from better-auth
-    const session = await auth.api.getSession({ headers: { cookie: cookieHeader } });
+    const session = await auth.api.getSession({ headers: request.headers });
     if (!session) {
       return NextResponse.json({ error: "Unauthorized: invalid or expired session" }, { status: 401 });
     }

--- a/src/app/api/leads/route.ts
+++ b/src/app/api/leads/route.ts
@@ -13,7 +13,7 @@ export async function GET(request: NextRequest) {
     if (!cookieHeader.includes("better-auth.session_token")) {
       return NextResponse.json({ error: "Unauthorized: missing session cookie" }, { status: 401 });
     }
-    const session = await auth.api.getSession({ headers: { cookie: cookieHeader } });
+    const session = await auth.api.getSession({ headers: request.headers });
     if (!session) {
       return NextResponse.json({ error: "Unauthorized: invalid or expired session" }, { status: 401 });
     }
@@ -222,7 +222,7 @@ export async function POST(request: NextRequest) {
     if (!cookieHeader.includes("better-auth.session_token")) {
       return NextResponse.json({ error: "Unauthorized: missing session cookie" }, { status: 401 });
     }
-    const session = await auth.api.getSession({ headers: { cookie: cookieHeader } });
+    const session = await auth.api.getSession({ headers: request.headers });
     if (!session) {
       return NextResponse.json({ error: "Unauthorized: invalid or expired session" }, { status: 401 });
     }
@@ -297,7 +297,7 @@ export async function PUT(request: NextRequest) {
     if (!cookieHeader.includes("better-auth.session_token")) {
       return NextResponse.json({ error: "Unauthorized: missing session cookie" }, { status: 401 });
     }
-    const session = await auth.api.getSession({ headers: { cookie: cookieHeader } });
+    const session = await auth.api.getSession({ headers: request.headers });
     if (!session) {
       return NextResponse.json({ error: "Unauthorized: invalid or expired session" }, { status: 401 });
     }

--- a/src/lib/store/leadDetailStore.ts
+++ b/src/lib/store/leadDetailStore.ts
@@ -1,5 +1,4 @@
 import { create } from "zustand";
-import { shallow } from "zustand/shallow";
 
 interface LeadDetailState {
   isOpen: boolean;

--- a/src/lib/store/uiStore.ts
+++ b/src/lib/store/uiStore.ts
@@ -1,5 +1,4 @@
 import { create } from "zustand";
-import { shallow } from "zustand/shallow";
 import { persist } from "zustand/middleware";
 
 interface UIState {
@@ -24,7 +23,7 @@ const initialState = {
 
 export const useUIStore = create<UIState>()(
   persist(
-    (set, _get) => ({
+    (set) => ({
       ...initialState,
       
       // Toggle sidebar collapsed state
@@ -68,21 +67,15 @@ export const useUIStore = create<UIState>()(
 
 // Selectors for better performance
 export const useSidebarState = () =>
-  useUIStore(
-    (state) => ({
-      sidebarCollapsed: state.sidebarCollapsed,
-      sidebarMobileOpen: state.sidebarMobileOpen,
-    }),
-    shallow
-  );
+  useUIStore((state) => ({
+    sidebarCollapsed: state.sidebarCollapsed,
+    sidebarMobileOpen: state.sidebarMobileOpen,
+  }));
 
 export const useSidebarActions = () =>
-  useUIStore(
-    (state) => ({
-      toggleSidebar: state.toggleSidebar,
-      setSidebarCollapsed: state.setSidebarCollapsed,
-      toggleSidebarMobile: state.toggleSidebarMobile,
-      setSidebarMobileOpen: state.setSidebarMobileOpen,
-    }),
-    shallow
-  );
+  useUIStore((state) => ({
+    toggleSidebar: state.toggleSidebar,
+    setSidebarCollapsed: state.setSidebarCollapsed,
+    toggleSidebarMobile: state.toggleSidebarMobile,
+    setSidebarMobileOpen: state.setSidebarMobileOpen,
+  }));


### PR DESCRIPTION
Fixes Vercel deployment by correcting `auth.api.getSession` header format and updating Zustand store usage for compatibility.

The primary issue was a TypeScript error where `auth.api.getSession` was incorrectly passed a plain object for headers, expecting a `Headers` object. This was resolved by passing `request.headers` directly. Additionally, deprecated `shallow` usage and an unused `_get` parameter in Zustand stores were updated to ensure a successful build.

---
<a href="https://cursor.com/background-agent?bcId=bc-4e0d2f3f-7858-4a7a-8f89-2d8ca45d4bd2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4e0d2f3f-7858-4a7a-8f89-2d8ca45d4bd2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

