### PR TITLE
Debug vercel build error: headers cookie

### DIFF
--- a/src/app/api/campaigns/route.ts
+++ b/src/app/api/campaigns/route.ts
@@ -12,7 +12,10 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized: missing session cookie" }, { status: 401 });
     }
     // Get session from better-auth
-    const session = await auth.api.getSession({ headers: { cookie: cookieHeader } });
+    const forwardedHeaders = new Headers(request.headers);
+    // Ensure cookie header is present on the forwarded headers
+    forwardedHeaders.set("cookie", cookieHeader);
+    const session = await auth.api.getSession({ headers: forwardedHeaders });
     if (!session) {
       return NextResponse.json({ error: "Unauthorized: invalid or expired session" }, { status: 401 });
     }
@@ -34,7 +37,7 @@ export async function GET(request: NextRequest) {
 
     // Calculate additional metrics for each campaign
     const campaignsWithMetrics = await Promise.all(
-      userCampaigns.map(async (campaign) => {
+      userCampaigns.map(async (campaign: { id: string; name: string; status: string; createdAt: Date; userId: string }) => {
         // TODO: Add actual lead counts and metrics calculation
         // For now, we'll return mock data
         const mockMetrics = {

--- a/src/app/api/leads/route.ts
+++ b/src/app/api/leads/route.ts
@@ -13,7 +13,9 @@ export async function GET(request: NextRequest) {
     if (!cookieHeader.includes("better-auth.session_token")) {
       return NextResponse.json({ error: "Unauthorized: missing session cookie" }, { status: 401 });
     }
-    const session = await auth.api.getSession({ headers: { cookie: cookieHeader } });
+    const forwardedHeaders = new Headers(request.headers);
+    forwardedHeaders.set("cookie", cookieHeader);
+    const session = await auth.api.getSession({ headers: forwardedHeaders });
     if (!session) {
       return NextResponse.json({ error: "Unauthorized: invalid or expired session" }, { status: 401 });
     }
@@ -197,10 +199,10 @@ export async function GET(request: NextRequest) {
         },
         summary: {
           totalLeads: totalLeads[0]?.count || 0,
-          statusCounts: statusCounts.reduce((acc, item) => {
+          statusCounts: statusCounts.reduce<Record<string, number>>((acc: Record<string, number>, item: { status: string; count: number }) => {
             acc[item.status] = item.count;
             return acc;
-          }, {} as Record<string, number>),
+          }, {}),
         },
       },
     });
@@ -222,7 +224,9 @@ export async function POST(request: NextRequest) {
     if (!cookieHeader.includes("better-auth.session_token")) {
       return NextResponse.json({ error: "Unauthorized: missing session cookie" }, { status: 401 });
     }
-    const session = await auth.api.getSession({ headers: { cookie: cookieHeader } });
+    const forwardedHeaders = new Headers(request.headers);
+    forwardedHeaders.set("cookie", cookieHeader);
+    const session = await auth.api.getSession({ headers: forwardedHeaders });
     if (!session) {
       return NextResponse.json({ error: "Unauthorized: invalid or expired session" }, { status: 401 });
     }
@@ -297,7 +301,9 @@ export async function PUT(request: NextRequest) {
     if (!cookieHeader.includes("better-auth.session_token")) {
       return NextResponse.json({ error: "Unauthorized: missing session cookie" }, { status: 401 });
     }
-    const session = await auth.api.getSession({ headers: { cookie: cookieHeader } });
+    const forwardedHeaders = new Headers(request.headers);
+    forwardedHeaders.set("cookie", cookieHeader);
+    const session = await auth.api.getSession({ headers: forwardedHeaders });
     if (!session) {
       return NextResponse.json({ error: "Unauthorized: invalid or expired session" }, { status: 401 });
     }


### PR DESCRIPTION
Fix Vercel build error by using proper `Headers` objects for session retrieval and add explicit types to resolve implicit any warnings.

The build error occurred because `auth.api.getSession` expected a `Headers` instance for its `headers` option, but was receiving a plain object `{ cookie: cookieHeader }`. This change constructs a `Headers` object and sets the cookie, resolving the type incompatibility during the Vercel build. Explicit types were also added to address TypeScript's implicit any warnings in array methods.

---
<a href="https://cursor.com/background-agent?bcId=bc-de512a18-41bd-4517-9a08-6651604c60f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-de512a18-41bd-4517-9a08-6651604c60f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

