### PR TITLE
Debug vercel build error: headers cookie

### DIFF
--- a/src/app/api/campaigns/route.ts
+++ b/src/app/api/campaigns/route.ts
@@ -6,13 +6,8 @@ import { auth } from "@/lib/auth";
 
 export async function GET(request: NextRequest) {
   try {
-    // Helpful diagnostics for 401s
-    const cookieHeader = request.headers.get("cookie") || "";
-    if (!cookieHeader.includes("better-auth.session_token")) {
-      return NextResponse.json({ error: "Unauthorized: missing session cookie" }, { status: 401 });
-    }
     // Get session from better-auth
-    const session = await auth.api.getSession({ headers: { cookie: cookieHeader } });
+    const session = await auth.api.getSession({ headers: request.headers });
     if (!session) {
       return NextResponse.json({ error: "Unauthorized: invalid or expired session" }, { status: 401 });
     }

--- a/src/app/api/leads/route.ts
+++ b/src/app/api/leads/route.ts
@@ -9,11 +9,7 @@ const MAX_PAGE_SIZE = 100;
 
 export async function GET(request: NextRequest) {
   try {
-    const cookieHeader = request.headers.get("cookie") || "";
-    if (!cookieHeader.includes("better-auth.session_token")) {
-      return NextResponse.json({ error: "Unauthorized: missing session cookie" }, { status: 401 });
-    }
-    const session = await auth.api.getSession({ headers: { cookie: cookieHeader } });
+    const session = await auth.api.getSession({ headers: request.headers });
     if (!session) {
       return NextResponse.json({ error: "Unauthorized: invalid or expired session" }, { status: 401 });
     }
@@ -218,11 +214,7 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
-    const cookieHeader = request.headers.get("cookie") || "";
-    if (!cookieHeader.includes("better-auth.session_token")) {
-      return NextResponse.json({ error: "Unauthorized: missing session cookie" }, { status: 401 });
-    }
-    const session = await auth.api.getSession({ headers: { cookie: cookieHeader } });
+    const session = await auth.api.getSession({ headers: request.headers });
     if (!session) {
       return NextResponse.json({ error: "Unauthorized: invalid or expired session" }, { status: 401 });
     }
@@ -293,11 +285,7 @@ export async function POST(request: NextRequest) {
 
 export async function PUT(request: NextRequest) {
   try {
-    const cookieHeader = request.headers.get("cookie") || "";
-    if (!cookieHeader.includes("better-auth.session_token")) {
-      return NextResponse.json({ error: "Unauthorized: missing session cookie" }, { status: 401 });
-    }
-    const session = await auth.api.getSession({ headers: { cookie: cookieHeader } });
+    const session = await auth.api.getSession({ headers: request.headers });
     if (!session) {
       return NextResponse.json({ error: "Unauthorized: invalid or expired session" }, { status: 401 });
     }

--- a/src/lib/store/uiStore.ts
+++ b/src/lib/store/uiStore.ts
@@ -1,5 +1,4 @@
 import { create } from "zustand";
-import { shallow } from "zustand/shallow";
 import { persist } from "zustand/middleware";
 
 interface UIState {
@@ -68,21 +67,15 @@ export const useUIStore = create<UIState>()(
 
 // Selectors for better performance
 export const useSidebarState = () =>
-  useUIStore(
-    (state) => ({
-      sidebarCollapsed: state.sidebarCollapsed,
-      sidebarMobileOpen: state.sidebarMobileOpen,
-    }),
-    shallow
-  );
+  useUIStore((state) => ({
+    sidebarCollapsed: state.sidebarCollapsed,
+    sidebarMobileOpen: state.sidebarMobileOpen,
+  }));
 
 export const useSidebarActions = () =>
-  useUIStore(
-    (state) => ({
-      toggleSidebar: state.toggleSidebar,
-      setSidebarCollapsed: state.setSidebarCollapsed,
-      toggleSidebarMobile: state.toggleSidebarMobile,
-      setSidebarMobileOpen: state.setSidebarMobileOpen,
-    }),
-    shallow
-  );
+  useUIStore((state) => ({
+    toggleSidebar: state.toggleSidebar,
+    setSidebarCollapsed: state.setSidebarCollapsed,
+    toggleSidebarMobile: state.toggleSidebarMobile,
+    setSidebarMobileOpen: state.setSidebarMobileOpen,
+  }));


### PR DESCRIPTION
Fix `auth.api.getSession` header type and update Zustand selectors to resolve Vercel build errors.

The Vercel build failed due to a TypeScript error where `auth.api.getSession` was called with an object literal `{ cookie: cookieHeader }` for headers, but it expected a `Headers` instance (like `request.headers`). Additionally, an incompatibility with Zustand v5 caused a build error due to `shallow` equality being incorrectly passed as a second argument to selectors.

---
<a href="https://cursor.com/background-agent?bcId=bc-632176a0-d6d2-486c-851e-674fecfc5715">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-632176a0-d6d2-486c-851e-674fecfc5715">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

